### PR TITLE
Clean up IAM policy. Moved policy actions accordingly to its corresponded resources

### DIFF
--- a/quick-start/prerequisites/permissions/msk-+serverless-setup.md
+++ b/quick-start/prerequisites/permissions/msk-+serverless-setup.md
@@ -31,13 +31,16 @@ KAFKA_CLUSTERS_0_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS='software.amazon.
 {
     "Version": "2012-10-17",
     "Statement": [
+        
         {
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
+                "kafka-cluster:Connect",
                 "kafka-cluster:DescribeCluster",
                 "kafka-cluster:AlterCluster",
-                "kafka-cluster:Connect"
+                "kafka-cluster:AlterClusterDynamicConfiguration",
+                "kafka-cluster:DescribeClusterDynamicConfiguration",
             ],
             "Resource": "arn:aws:kafka:eu-central-1:297478128798:cluster/test-wizard/7b39802a-21ac-48fe-b6e8-a7baf2ae2533-s2"
         },
@@ -45,22 +48,14 @@ KAFKA_CLUSTERS_0_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS='software.amazon.
             "Sid": "VisualEditor1",
             "Effect": "Allow",
             "Action": [
-                "kafka-cluster:DeleteGroup",
-                "kafka-cluster:DescribeCluster",
                 "kafka-cluster:ReadData",
+                "kafka-cluster:WriteData",
                 "kafka-cluster:DescribeTopicDynamicConfiguration",
                 "kafka-cluster:AlterTopicDynamicConfiguration",
-                "kafka-cluster:AlterGroup",
-                "kafka-cluster:AlterClusterDynamicConfiguration",
                 "kafka-cluster:AlterTopic",
                 "kafka-cluster:CreateTopic",
                 "kafka-cluster:DescribeTopic",
-                "kafka-cluster:AlterCluster",
-                "kafka-cluster:DescribeGroup",
-                "kafka-cluster:DescribeClusterDynamicConfiguration",
-                "kafka-cluster:Connect",
-                "kafka-cluster:DeleteTopic",
-                "kafka-cluster:WriteData"
+                "kafka-cluster:DeleteTopic"
             ],
             "Resource": "arn:aws:kafka:eu-central-1:297478128798:topic/test-wizard/7b39802a-21ac-48fe-b6e8-a7baf2ae2533-s2/*"
         },
@@ -68,8 +63,9 @@ KAFKA_CLUSTERS_0_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS='software.amazon.
             "Sid": "VisualEditor2",
             "Effect": "Allow",
             "Action": [
-                "kafka-cluster:AlterGroup",
-                "kafka-cluster:DescribeGroup"
+                "kafka-cluster:DeleteGroup",
+                "kafka-cluster:DescribeGroup",
+                "kafka-cluster:AlterGroup"
             ],
             "Resource": "arn:aws:kafka:eu-central-1:297478128798:group/test-wizard/7b39802a-21ac-48fe-b6e8-a7baf2ae2533-s2/*"
         }


### PR DESCRIPTION
This PR fixes the issues where policy actions are not related to the policy resources, for e.g.

```
...
 {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": [
                "kafka-cluster:DeleteGroup",
                ...
            ],
            "Resource": "arn:aws:kafka:eu-central-1:297478128798:topic/test-wizard/7b39802a-21ac-48fe-b6e8-a7baf2ae2533-s2/*"
        },
...
```
Policy action `kafka-cluster:DeleteGroup` requires `group` resource and it has no impact on `topic` resource.
This change will make example configuration clean and accurate.

More details on policy actions and corresponding groups can be found in this [AWS MSK IAM doc](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html#kafka-actions).

P.S. thanks for Kafka-UI ❤️ 

