### PR TITLE
feat: add custom-params.type oauth for keycloak

### DIFF
--- a/configuration/authentication/oauth2.md
+++ b/configuration/authentication/oauth2.md
@@ -208,5 +208,5 @@ auth:
         client-name: keycloak
         provider: keycloak
         custom-params:
-          type: keycloak
+          type: oauth
 ```


### PR DESCRIPTION
For my keycloak configuration works i have set `custom-param.type` to `oauth` and not `keycloak` value.