### PR TITLE
Fix existingSecret name in ssl-values.yaml example.

### DIFF
--- a/configuration/helm-charts/configuration/ssl-example.md
+++ b/configuration/helm-charts/configuration/ssl-example.md
@@ -42,7 +42,7 @@ data:
 ### Create ssl-values.yaml file with the following content.
 
 ```
-existingSecret: "ssl-files"
+existingSecret: "ssl-secret"
 
 
 env:


### PR DESCRIPTION
In the current SSL example configuration for the Helm we create secret with 'ssl-secret' name but then use wrong secret name in existingSecret value.